### PR TITLE
Added Edge Support.

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -61,10 +61,27 @@ var (
 			"QIHU",
 			"QQBrowser",
 			"SE ",
+			"Edge",
 			"MetaSr",
 			"TaoBrowser",
 		},
 		versionSplitters: [][]string{[]string{"Chrome/", " "}},
+	}
+
+	edge = &itemSpec{
+		name:         "Edge",
+		mustContains: []string{"Chrome", "Edge"},
+		mustNotContains: []string{
+			"CoolNovo",
+			"LBBROWSER",
+			"Maxthon",
+			"QIHU",
+			"QQBrowser",
+			"SE ",
+			"MetaSr",
+			"TaoBrowser",
+		},
+		versionSplitters: [][]string{[]string{"Edge/", " "}},
 	}
 
 	opera = &itemSpec{
@@ -128,6 +145,7 @@ var (
 		firefox,
 		safari,
 		chrome,
+		edge,
 		opera,
 		_360se,
 		sougou,


### PR DESCRIPTION
Edge apparently likes to pretend to be chrome. I added edge support following [this stackoverflow post](http://stackoverflow.com/a/31279980).
Resolves https://github.com/varstr/uaparser/issues/4.